### PR TITLE
Use ffmpeg for audio extraction

### DIFF
--- a/audio_extractor.py
+++ b/audio_extractor.py
@@ -1,10 +1,31 @@
-"""Audio extraction module for meeting AI agent."""
+"""Audio extraction module for meeting AI agent.
 
-from moviepy.editor import VideoFileClip
+This implementation avoids depending on ``moviepy`` which is not available in
+the execution environment.  Instead, the widely available ``ffmpeg`` command
+line tool is used to extract the audio track from a video file.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import shutil
 
 
 def extract_audio(video_path: str, audio_path: str) -> str:
-    """Extract audio track from the video file."""
-    clip = VideoFileClip(video_path)
-    clip.audio.write_audiofile(audio_path, verbose=False, logger=None)
+    """Extract the audio track from ``video_path`` and store it at
+    ``audio_path``.
+
+    The function relies on the ``ffmpeg`` binary.  If ``ffmpeg`` is not found on
+    the system, a :class:`RuntimeError` is raised with installation guidance.
+    """
+
+    ffmpeg_path = shutil.which("ffmpeg")
+    if ffmpeg_path is None:
+        raise RuntimeError(
+            "ffmpeg is required to extract audio but was not found. "
+            "Please install ffmpeg and ensure it is in your PATH."
+        )
+
+    cmd = [ffmpeg_path, "-y", "-i", video_path, audio_path]
+    subprocess.run(cmd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
     return audio_path

--- a/meeting_ai_agent.py
+++ b/meeting_ai_agent.py
@@ -35,16 +35,24 @@ def run(args: SummaryRequest) -> str:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="Meeting summarizer AI agent")
-    parser.add_argument("video", help="Path to Teams video recording")
-    parser.add_argument("--date", required=True, help="Meeting date")
+    parser.add_argument("video", nargs="?", help="Path to Teams video recording")
+    parser.add_argument("--date", help="Meeting date")
     parser.add_argument(
         "--attendees",
-        nargs="+",
-        required=True,
+        nargs="*",
         help="List of attendees",
     )
     parser.add_argument("--output", help="Output file for the summary")
     args_ns = parser.parse_args()
+    if not args_ns.video:
+        args_ns.video = input("Video file: ").strip()
+    if not args_ns.date:
+        args_ns.date = input("Meeting date: ").strip()
+    if not args_ns.attendees:
+        attendees_raw = input("Attendees (comma-separated): ").strip()
+        args_ns.attendees = [a.strip() for a in attendees_raw.split(",") if a.strip()]
+    if not args_ns.video or not args_ns.date or not args_ns.attendees:
+        parser.error("video, --date, and --attendees are required.")
     args = SummaryRequest(
         video_path=args_ns.video,
         meeting_date=args_ns.date,

--- a/whisper_transcriber.py
+++ b/whisper_transcriber.py
@@ -1,10 +1,23 @@
 """Whisper transcription module with Malayalam support."""
 
-import whisper
+from __future__ import annotations
 
 
 def transcribe(audio_path: str) -> str:
-    """Transcribe Malayalam audio to English using Whisper."""
+    """Transcribe Malayalam audio to English using Whisper.
+
+    The function requires the ``whisper`` package.  If it is not installed a
+    :class:`RuntimeError` is raised with instructions on how to install it.
+    """
+
+    try:
+        import whisper
+    except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+        raise RuntimeError(
+            "The 'whisper' package is required for transcription. "
+            "Install it with 'pip install -U openai-whisper'."
+        ) from exc
+
     model = whisper.load_model("small")
     # Specify language to ensure Malayalam recognition
     result = model.transcribe(audio_path, task="translate", language="ml")


### PR DESCRIPTION
## Summary
- replace dependency on `moviepy` with a lightweight ffmpeg-based audio extraction utility.
- raise a clear error when ffmpeg is unavailable to guide installation.
- handle missing `whisper` dependency with an import guard and installation instructions.
- prompt for missing command-line arguments so the meeting agent can run interactively instead of exiting.

## Testing
- `python -m py_compile audio_extractor.py meeting_ai_agent.py issue_summarizer.py text_normalizer.py whisper_transcriber.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a1d0ac15c832c9ecec1a69e05f914