### PR TITLE
Prompt for meeting video path interactively

### DIFF
--- a/issue_summarizer.py
+++ b/issue_summarizer.py
@@ -2,19 +2,27 @@
 
 from __future__ import annotations
 
-from typing import List
+from typing import List, Optional
 
 from transformers import pipeline
 
 
-def summarize(text: str, meeting_date: str, attendees: List[str]) -> str:
+def summarize(
+    text: str,
+    meeting_date: Optional[str] = None,
+    attendees: Optional[List[str]] = None,
+) -> str:
     """Generate structured summary from transcript."""
     summarizer = pipeline("text2text-generation", model="google/flan-t5-base")
     prompt = (
         "You are a corporate meeting assistant. Using the transcript, summarize each "
         "issue discussed and list decisions and **action items** with owners and "
-        "deadlines. Format with headings and bullet points. Meeting date: "
-        f"{meeting_date}. Attendees: {', '.join(attendees)}. Transcript: "
+        "deadlines. Format with headings and bullet points. "
     )
+    if meeting_date:
+        prompt += f"Meeting date: {meeting_date}. "
+    if attendees:
+        prompt += f"Attendees: {', '.join(attendees)}. "
+    prompt += "Transcript: "
     output = summarizer(prompt + text, max_length=512)[0]["generated_text"]
     return output

--- a/meeting_ai_agent.py
+++ b/meeting_ai_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
-from typing import List
+from typing import List, Optional
 
 from audio_extractor import extract_audio
 from whisper_transcriber import transcribe
@@ -16,8 +16,8 @@ from issue_summarizer import summarize
 @dataclass
 class SummaryRequest:
     video_path: str
-    meeting_date: str
-    attendees: List[str]
+    meeting_date: Optional[str] = None
+    attendees: Optional[List[str]] = None
     output_path: str | None = None
 
 
@@ -46,13 +46,6 @@ def main() -> None:
     args_ns = parser.parse_args()
     if not args_ns.video:
         args_ns.video = input("Video file: ").strip()
-    if not args_ns.date:
-        args_ns.date = input("Meeting date: ").strip()
-    if not args_ns.attendees:
-        attendees_raw = input("Attendees (comma-separated): ").strip()
-        args_ns.attendees = [a.strip() for a in attendees_raw.split(",") if a.strip()]
-    if not args_ns.video or not args_ns.date or not args_ns.attendees:
-        parser.error("video, --date, and --attendees are required.")
     args = SummaryRequest(
         video_path=args_ns.video,
         meeting_date=args_ns.date,


### PR DESCRIPTION
## Summary
- Allow `meeting_ai_agent.py` to prompt for the meeting video path when run without arguments
- Make meeting date and attendees optional in both the agent and summarizer
- Enable summarizer to build prompts with optional meeting metadata

## Testing
- `python -m py_compile meeting_ai_agent.py issue_summarizer.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b73ef06d0832cab594bf83a9aefec