### PR TITLE
Preload issue summarizer pipeline

### DIFF
--- a/issue_summarizer.py
+++ b/issue_summarizer.py
@@ -6,6 +6,10 @@ from typing import List, Optional
 
 from transformers import pipeline
 
+# Preload the text generation pipeline once at module import to avoid
+# re-initializing the model on every summarize call.
+summarizer = pipeline("text2text-generation", model="google/flan-t5-base")
+
 
 def summarize(
     text: str,
@@ -13,7 +17,6 @@ def summarize(
     attendees: Optional[List[str]] = None,
 ) -> str:
     """Generate structured summary from transcript."""
-    summarizer = pipeline("text2text-generation", model="google/flan-t5-base")
     prompt = (
         "You are a corporate meeting assistant. Using the transcript, summarize each "
         "issue discussed and list decisions and **action items** with owners and "


### PR DESCRIPTION
## Summary
- preload Flan-T5 text2text-generation pipeline at import
- reuse the preloaded pipeline for meeting issue summaries

## Testing
- `python -m py_compile issue_summarizer.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b85c7f798832c8bef85f9cfdd6274