### PR TITLE
feat: allow selecting Whisper model

### DIFF
--- a/meeting_ai_agent.py
+++ b/meeting_ai_agent.py
@@ -19,12 +19,13 @@ class SummaryRequest:
     meeting_date: Optional[str] = None
     attendees: Optional[List[str]] = None
     output_path: str | None = None
+    model_name: str = "small"
 
 
 def run(args: SummaryRequest) -> str:
     audio_path = os.path.splitext(args.video_path)[0] + ".wav"
     extract_audio(args.video_path, audio_path)
-    transcript = transcribe(audio_path)
+    transcript = transcribe(audio_path, model_name=args.model_name)
     cleaned = normalize_text(transcript)
     summary = summarize(cleaned, args.meeting_date, args.attendees)
     if args.output_path:
@@ -43,6 +44,11 @@ def main() -> None:
         help="List of attendees",
     )
     parser.add_argument("--output", help="Output file for the summary")
+    parser.add_argument(
+        "--model-name",
+        default="small",
+        help="Whisper model to use for transcription",
+    )
     args_ns = parser.parse_args()
     if not args_ns.video:
         args_ns.video = input("Video file: ").strip()
@@ -51,6 +57,7 @@ def main() -> None:
         meeting_date=args_ns.date,
         attendees=args_ns.attendees,
         output_path=args_ns.output,
+        model_name=args_ns.model_name,
     )
     summary = run(args)
     print(summary)

--- a/whisper_transcriber.py
+++ b/whisper_transcriber.py
@@ -3,8 +3,15 @@
 from __future__ import annotations
 
 
-def transcribe(audio_path: str) -> str:
+def transcribe(audio_path: str, model_name: str = "small") -> str:
     """Transcribe Malayalam audio to English using Whisper.
+
+    Parameters
+    ----------
+    audio_path:
+        Path to the audio file to transcribe.
+    model_name:
+        Name of the Whisper model to load.  Defaults to ``"small"``.
 
     The function requires the ``whisper`` package.  If it is not installed a
     :class:`RuntimeError` is raised with instructions on how to install it.
@@ -18,7 +25,7 @@ def transcribe(audio_path: str) -> str:
             "Install it with 'pip install -U openai-whisper'."
         ) from exc
 
-    model = whisper.load_model("small")
+    model = whisper.load_model(model_name)
     # Specify language to ensure Malayalam recognition
     result = model.transcribe(audio_path, task="translate", language="ml")
     return result["text"].strip()


### PR DESCRIPTION
## Summary
- allow selecting Whisper model via optional `model_name` argument
- expose `--model-name` option in meeting agent

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689b8d5b55dc832cbd83287389823863