### PR TITLE
Improve text normalization and terminology mapping

### DIFF
--- a/tests/test_text_normalizer.py
+++ b/tests/test_text_normalizer.py
@@ -1,0 +1,17 @@
+import os
+import sys
+
+import pytest
+
+# Ensure the project root is on the import path
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from text_normalizer import normalize_text
+
+def test_normalize_removes_fillers_and_whitespace():
+    result = normalize_text("Um, this   is a Test!!")
+    assert result == "this is a test"
+
+def test_normalize_maps_terms():
+    text = "Setting up the API in Prod"
+    result = normalize_text(text)
+    assert result == "deployment the application programming interface in production"

--- a/text_normalizer.py
+++ b/text_normalizer.py
@@ -4,29 +4,58 @@ from __future__ import annotations
 
 import re
 
+# Common filler words and verbal pauses that should be removed from transcripts
 FILLER_WORDS = {
     "um",
     "uh",
     "ah",
     "er",
     "mmm",
+    "umm",
+    "uhh",
+    "hmm",
+    "like",
+    "so",
+    "actually",
+    "basically",
+    "ok",
+    "okay",
 }
 
+# Corporate terminology and abbreviations mapped to their preferred forms
 TERMINOLOGY_MAP = {
     "setting up": "deployment",
     "set up": "deploy",
     "setup": "deployment",
+    "config": "configuration",
+    "configs": "configurations",
+    "ai": "artificial intelligence",
+    "api": "application programming interface",
+    "db": "database",
+    "prod": "production",
+    "dev": "development",
 }
 
 
 def normalize_text(text: str) -> str:
-    """Remove filler words and standardize corporate terminology."""
+    """Normalize raw text by cleaning fillers, casing, punctuation, whitespace, and terminology."""
+
+    # Standardize casing
+    cleaned = text.lower()
+
+    # Remove stray punctuation
+    cleaned = re.sub(r"[^\w\s]", "", cleaned)
+
+    # Collapse repeated whitespace
+    cleaned = re.sub(r"\s+", " ", cleaned).strip()
 
     def remove_fillers(token: str) -> bool:
-        return token.lower() not in FILLER_WORDS
+        return token not in FILLER_WORDS
 
-    tokens = filter(remove_fillers, re.split(r"\s+", text))
+    tokens = filter(remove_fillers, cleaned.split())
     cleaned = " ".join(tokens)
+
     for src, tgt in TERMINOLOGY_MAP.items():
         cleaned = re.sub(rf"\b{re.escape(src)}\b", tgt, cleaned, flags=re.IGNORECASE)
+
     return cleaned


### PR DESCRIPTION
## Summary
- standardize casing, strip punctuation, and normalize whitespace
- remove additional filler words and map more corporate abbreviations
- add tests covering normalization behaviors

## Testing
- `pytest tests/test_text_normalizer.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689eb5096960832cb1832cc396986b04