### PR TITLE
Refine issue summarizer token handling

### DIFF
--- a/issue_summarizer.py
+++ b/issue_summarizer.py
@@ -12,6 +12,20 @@ summarizer = pipeline("text2text-generation", model="google/flan-t5-base")
 tokenizer = summarizer.tokenizer
 
 
+def _generate(prompt: str) -> str:
+    """Run the underlying model with safe tokenization and decoding."""
+
+    inputs = tokenizer(
+        prompt,
+        truncation=True,
+        max_length=tokenizer.model_max_length,
+        return_tensors="pt",
+    )
+    inputs = {k: v.to(summarizer.model.device) for k, v in inputs.items()}
+    output_ids = summarizer.model.generate(**inputs, max_new_tokens=256)
+    return tokenizer.decode(output_ids[0], skip_special_tokens=True)
+
+
 def _chunk_text(text: str, max_tokens: int = 350) -> List[str]:
     """Split ``text`` into chunks of approximately ``max_tokens`` tokens.
 
@@ -52,17 +66,19 @@ def summarize(
     chunks = _chunk_text(text)
     partial_summaries: List[str] = []
     for chunk in chunks:
-        prompt = base_prompt + "Transcript: "
-        partial = summarizer(prompt + chunk, max_length=512)[0]["generated_text"]
-        partial_summaries.append(partial)
+        prompt = base_prompt + "Transcript: " + chunk
+        partial_summaries.append(_generate(prompt))
 
-    if len(partial_summaries) == 1:
-        return partial_summaries[0]
+    combined = " ".join(partial_summaries)
+    while True:
+        final_prompt = base_prompt + "Partial summaries: " + combined
+        token_len = len(tokenizer(final_prompt, return_tensors="pt")["input_ids"][0])
+        if token_len <= tokenizer.model_max_length:
+            return _generate(final_prompt)
 
-    final_prompt = (
-        base_prompt
-        + "Partial summaries: "
-        + " ".join(partial_summaries)
-    )
-    final_summary = summarizer(final_prompt, max_length=512)[0]["generated_text"]
-    return final_summary
+        combined_chunks = _chunk_text(combined)
+        new_partials: List[str] = []
+        for part in combined_chunks:
+            prompt = base_prompt + "Partial summaries: " + part
+            new_partials.append(_generate(prompt))
+        combined = " ".join(new_partials)


### PR DESCRIPTION
## Summary
- Ensure summarizer uses `max_new_tokens` to avoid input truncation
- Tokenize prompts with truncation and re-chunk long partial summaries

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1842e5ba0832c804de01393ce1ae6